### PR TITLE
add optional headers to blob PUT requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ let blob = await storage
 let res = await blob.put(
   new TextEncoder().encode('Hello World'), // Blob or BufferSource
   'text/plain' // Content-Type
+  // { 'Content-MD5': xxx } // additional headers (optional)
 )
 
 console.log('Succeed:': res.ok)

--- a/container.ts
+++ b/container.ts
@@ -117,8 +117,9 @@ export class ContainerFile {
     return this.#path
   }
 
-  put(data: Blob | BufferSource, contentType: string): Promise<Response> {
+  put(data: Blob | BufferSource, contentType: string, additionalHeaders?: PutHeaders): Promise<Response> {
     return this.#container.fetch('put', `${this.#container.name}/${this.#path}`, data, {
+      ...additionalHeaders,
       'Content-Type': contentType
     })
   }
@@ -130,4 +131,15 @@ export class ContainerFile {
   delete(): Promise<Response> {
     return this.#container.fetch('delete', `${this.#container.name}/${this.#path}`)
   }
+}
+
+/** A subset of headers that can be used in put method
+ *  @see https://learn.microsoft.com/en-us/rest/api/storageservices/put-blob#request-headers-all-blob-types
+ */ 
+type PutHeaders = {
+  "Cache-Control"?: string
+  "Content-MD5"?: string
+  "Content-Encoding"?: string
+  "Content-Language"?: string
+  "x-ms-blob-content-disposition"?: string
 }


### PR DESCRIPTION
I noticed `put` requests only allow setting the `Content-Type` header. Other headers are needed to get some blob types working correctly. E.g. a JSON file that has been compressed with brotli will need both `Content-Type: 'application/json'` and `Content-Encoding: br` set.

This PR adds an optional third parameter to `put` to pass additional headers.